### PR TITLE
Do case insensitive search when clicking on a tag

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -155,7 +155,7 @@ function getEntriesByTag($tag, $limit = 10, $offset = 0) {
                           FROM entries e 
                           JOIN entry_tags et ON e.id = et.entry_id 
                           JOIN tags t ON et.tag_id = t.id 
-                          WHERE t.name = :tag 
+                          WHERE lower(t.name) = :tag 
                           GROUP BY e.id ORDER BY e.timestamp DESC 
                           LIMIT :limit OFFSET :offset");
 

--- a/stats.php
+++ b/stats.php
@@ -1,9 +1,6 @@
 <?php
 require 'bootstrap.php';
 
-// Database connection
-$db = new PDO('sqlite:journal.db');
-$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 // Total entries
 $totalEntries = $db->query("SELECT COUNT(*) FROM entries")->fetchColumn();

--- a/tag.php
+++ b/tag.php
@@ -1,7 +1,7 @@
 <?php
 require 'bootstrap.php';
 
-$tag = $_GET['tag'] ?? '';
+$tag = strtolower($_GET['tag']) ?? '';
 
 if (!$tag) {
     die('Tag not specified.');
@@ -19,7 +19,7 @@ global $db;
 $totalEntries = $db->prepare("SELECT COUNT(DISTINCT e.id) FROM entries e 
                               JOIN entry_tags et ON e.id = et.entry_id 
                               JOIN tags t ON et.tag_id = t.id 
-                              WHERE t.name = :tag");
+                              WHERE lower(t.name) = :tag");
 $totalEntries->execute([':tag' => $tag]);
 $totalEntries = $totalEntries->fetchColumn();
 $totalPages = ceil($totalEntries / $limit);


### PR DESCRIPTION
The search function does a case insensitive search, as it uses LIKE.  This PR does the same when clicking on a specific tag on an entry.
