### PR TITLE
fix typo

### DIFF
--- a/search.php
+++ b/search.php
@@ -41,7 +41,7 @@ if (!empty($query)) {
                 type="text" 
                 id="search" 
                 name="q" 
-                value="<?php echo htmlspecialchars($q); ?>" 
+                value="<?php echo htmlspecialchars($query); ?>" 
                 placeholder="e.g. kids, work, holiday..." 
                 required autofocus>
             <button type="submit">Search</button>


### PR DESCRIPTION
A typo in the query string used to display it in the field was causing a error:

`<br /><b>Warning</b>:  Undefined variable $q in <b>\home\daj\html\journal\search.php</b> on line <b>44</b><br />`

